### PR TITLE
use opn instead of open

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const open = require('open');
+const open = require('opn');
 const Server = require('./src/server');
 
 const DefaultPort = 6060;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "markdown-it-anchor": "^2.3.0",
     "markdown-it-checkbox": "^1.1.0",
     "markdown-it-emoji": "^1.1.0",
-    "open": "0.0.5",
+    "opn": "^3.0.3",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
     "react-render-html": "0.1.3",


### PR DESCRIPTION
[opn](https://github.com/sindresorhus/opn) is currently maintained, unlike `open`.

Also, it works correctly on my machine. Unlike `open`, which opens three Firefox tabs: `www.http.com`, `file:////localhost` and `6060/README.md` :D